### PR TITLE
Fix interpolation overflow for euler angles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/gadomski/pos-rs"
 repository = "https://github.com/gadomski/pos-rs"
 keywords = ["gis", "gnss", "imu", "sbet"]
 exclude = ["data/*"]
+edition = "2021"
 
 [dependencies]
 byteorder = "1.2"

--- a/data/0916_2014_ie.pos
+++ b/data/0916_2014_ie.pos
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c5026dbf502281e2a297a4f42a9eee41b79b05dcb415dc1109529f41815e188d
-size 65052011

--- a/data/sbet_mission_1.pof
+++ b/data/sbet_mission_1.pof
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e3f7dc0a7319b8241ea2ca9bcac68c242810586275b137129a98b0cf89446397
-size 71329744

--- a/data/sbet_mission_1.poq
+++ b/data/sbet_mission_1.poq
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cd907bd00f75afeead0f7e053e496b5b9ca2bac61211048ca2cc23ac7cd3c3fc
-size 378963

--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -1,8 +1,8 @@
 //! Interpolate between two position points.
 
 use failure;
-use point::Point;
-use source::Source;
+use crate::point::Point;
+use crate::source::Source;
 
 /// Errors for interpolation.
 #[derive(Clone, Copy, Debug, Fail)]
@@ -24,7 +24,7 @@ pub enum Error {
 #[derive(Debug)]
 pub struct Interpolator {
     index: usize,
-    source: Box<Source>,
+    source: Box<dyn Source>,
     points: Vec<Point>,
 }
 
@@ -39,7 +39,7 @@ impl Interpolator {
     /// let reader = sbet::Reader::from_path("data/2-points.sbet").unwrap();
     /// let interpolator = Interpolator::new(Box::new(reader)).unwrap();
     /// ```
-    pub fn new(mut source: Box<Source>) -> Result<Interpolator, failure::Error> {
+    pub fn new(mut source: Box<dyn Source>) -> Result<Interpolator, failure::Error> {
         let mut points = Vec::with_capacity(2);
         for _ in 0..2 {
             points.push(match source.source()? {
@@ -105,7 +105,7 @@ impl Interpolator {
 mod tests {
     use super::*;
 
-    use sbet;
+    use crate::sbet;
 
     #[test]
     fn interp_sbet() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
         trivial_numeric_casts, unsafe_code, unused_extern_crates, unused_import_braces,
         unused_qualifications, unused_results, variant_size_differences)]
 
-extern crate byteorder;
 #[macro_use]
 extern crate failure;
 

--- a/src/pof.rs
+++ b/src/pof.rs
@@ -4,14 +4,14 @@
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use failure;
-use point::Point;
-use source::Source;
+use crate::point::Point;
+use crate::source::Source;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::iter::IntoIterator;
 use std::path::Path;
-use units::Radians;
+use crate::units::Radians;
 
 /// Pof errors.
 #[derive(Clone, Copy, Debug, Fail)]

--- a/src/point.rs
+++ b/src/point.rs
@@ -11,7 +11,7 @@ macro_rules! interpolate {
     }}
 }
 
-macro_rules! interpolate_angle {
+macro_rules! interpolate_euler {
     ($lhs:ident, $rhs:ident, $factor:ident, $var:ident) => {{
         let mut diff = $rhs.$var.0 - $lhs.$var.0;
         if diff > PI {
@@ -85,9 +85,9 @@ impl Point {
             longitude: interpolate!(self, other, factor, longitude),
             latitude: interpolate!(self, other, factor, latitude),
             altitude: interpolate!(self, other, factor, altitude),
-            roll: interpolate_angle!(self, other, factor, roll),
-            pitch: interpolate_angle!(self, other, factor, pitch),
-            yaw: interpolate_angle!(self, other, factor, yaw),
+            roll: interpolate_euler!(self, other, factor, roll),
+            pitch: interpolate_euler!(self, other, factor, pitch),
+            yaw: interpolate_euler!(self, other, factor, yaw),
             distance: interpolate_optional!(self, other, factor, distance),
             x_velocity: interpolate_optional!(self, other, factor, x_velocity),
             y_velocity: interpolate_optional!(self, other, factor, y_velocity),
@@ -174,5 +174,36 @@ pub enum SatelliteCount {
 impl Default for SatelliteCount {
     fn default() -> SatelliteCount {
         SatelliteCount::Unspecified(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn test_interpolate_angle() {
+        let point_1 = Point {
+            time: 0.0,
+            roll: Radians(0.0),
+            pitch: Radians(0.0),
+            yaw: Radians(175.0f64.to_radians()),
+            ..Default::default()
+        };
+        let point_2 = Point {
+            time: 1.0,
+            roll: Radians(0.0),
+            pitch: Radians(0.0),
+            yaw: Radians(-175.0f64.to_radians()),
+            ..Default::default()
+        };
+
+        let interpolated = point_1.interpolate(&point_2, 0.5);
+        dbg!(interpolated.yaw);
+        let expected_yaw = 180.0f64.to_radians();
+        let calculated_diff = (interpolated.yaw.0 - expected_yaw).abs();
+
+        assert!(calculated_diff < 0.0001);
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,11 +1,26 @@
 //! Points.
 
+use std::f64::consts::PI;
 use crate::units::Radians;
 
+const TWO_PI: f64 = PI * 2.0;
 
 macro_rules! interpolate {
     ($lhs:ident, $rhs:ident, $factor:ident, $var:ident) => {{
         $lhs.$var + $factor * ($rhs.$var - $lhs.$var)
+    }}
+}
+
+macro_rules! interpolate_angle {
+    ($lhs:ident, $rhs:ident, $factor:ident, $var:ident) => {{
+        let mut diff = $rhs.$var.0 - $lhs.$var.0;
+        if diff > PI {
+            diff = diff - TWO_PI;
+        } else if diff < -PI {
+            diff = diff + TWO_PI;
+        }
+
+        Radians((TWO_PI + $lhs.$var.0 + $factor * diff) % TWO_PI)
     }}
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,6 +1,7 @@
 //! Points.
 
-use units::Radians;
+use crate::units::Radians;
+
 
 macro_rules! interpolate {
     ($lhs:ident, $rhs:ident, $factor:ident, $var:ident) => {{
@@ -69,9 +70,9 @@ impl Point {
             longitude: interpolate!(self, other, factor, longitude),
             latitude: interpolate!(self, other, factor, latitude),
             altitude: interpolate!(self, other, factor, altitude),
-            roll: interpolate!(self, other, factor, roll),
-            pitch: interpolate!(self, other, factor, pitch),
-            yaw: interpolate!(self, other, factor, yaw),
+            roll: interpolate_angle!(self, other, factor, roll),
+            pitch: interpolate_angle!(self, other, factor, pitch),
+            yaw: interpolate_angle!(self, other, factor, yaw),
             distance: interpolate_optional!(self, other, factor, distance),
             x_velocity: interpolate_optional!(self, other, factor, x_velocity),
             y_velocity: interpolate_optional!(self, other, factor, y_velocity),

--- a/src/poq.rs
+++ b/src/poq.rs
@@ -2,12 +2,12 @@
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use failure::Error;
-use point::{Accuracy, SatelliteCount};
+use crate::point::{Accuracy, SatelliteCount};
 use std::fs::File;
 use std::io::{BufReader, Read, Seek};
 use std::iter::IntoIterator;
 use std::path::Path;
-use units::Radians;
+use crate::units::Radians;
 
 /// A poq file reader.
 #[derive(Debug)]

--- a/src/pos.rs
+++ b/src/pos.rs
@@ -1,13 +1,13 @@
 //! Pos files are ASCII position files.
 
 use failure::Error;
-use point::Point;
-use source::Source;
+use crate::point::Point;
+use crate::source::Source;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
-use units::Radians;
+use crate::units::Radians;
 
 /// A pos reader.
 #[derive(Debug)]
@@ -45,7 +45,7 @@ impl<R: BufRead> Reader<R> {
     pub fn read_point(&mut self) -> Result<Option<Point>, Error> {
         let mut line = String::new();
         let _ = self.reader.read_line(&mut line)?;
-        let values: Vec<_> = line.split_whitespace().map(|s| s.clone()).collect();
+        let values: Vec<_> = line.split_whitespace().map(|s| s).collect();
         if values.is_empty() {
             return Ok(None);
         }

--- a/src/sbet.rs
+++ b/src/sbet.rs
@@ -2,14 +2,14 @@
 
 use byteorder::{LittleEndian, ReadBytesExt};
 use failure::Error;
-use point::Point;
-use source::Source;
+use crate::point::Point;
+use crate::source::Source;
 use std::fmt::Debug;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::iter::IntoIterator;
 use std::path::Path;
-use units::Radians;
+use crate::units::Radians;
 
 /// An SBET reader.
 #[derive(Debug)]


### PR DESCRIPTION
When interpolating Euler angles (yaw, pitch, roll) and the diff between the 2 values is greater than PI, the interpolation currently gives wrong results.

For example:
- yaw 1: 355 degrees
- yaw 2: 5 degrees

This would currently result in 180 degrees, whereas 0 should be the correct result. This PR fixes that.